### PR TITLE
Only test AbortController if defined

### DIFF
--- a/tests/api.test.js
+++ b/tests/api.test.js
@@ -119,19 +119,23 @@ describe('Mocking aborts', () => {
   });
 
   it('throws when passed an already aborted abort signal in the request init', () => {
-    const c = new AbortController();
-    c.abort();
-    expect(() => fetch('/', { signal: c.signal })).toThrow(expect.any(DOMException));
+    if (typeof AbortController !== 'undefined') {
+      const c = new AbortController();
+      c.abort();
+      expect(() => fetch('/', { signal: c.signal })).toThrow(expect.any(DOMException));
+    }
   });
 
   it('rejects when aborted before resolved', async () => {
-    const c = new AbortController();
-    fetch.mockResponse(async () => {
-      vi.advanceTimersByTime(60);
-      return '';
-    });
-    setTimeout(() => c.abort(), 50);
-    await expect(fetch('/', { signal: c.signal })).rejects.toThrow(expect.any(DOMException));
+    if (typeof AbortController !== 'undefined') {
+      const c = new AbortController();
+      fetch.mockResponse(async () => {
+        vi.advanceTimersByTime(60);
+        return '';
+      });
+      setTimeout(() => c.abort(), 50);
+      await expect(fetch('/', { signal: c.signal })).rejects.toThrow(expect.any(DOMException));
+    }
   });
 });
 


### PR DESCRIPTION
`AbortController` was not introduced until node 15.  Not sure how this is passing in jest-fetch-mock back to node 10, but I'm guessing it's due to the `domexception` polyfill.