### PR TITLE
feat: allow passing null or undefined as response body

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -259,7 +259,7 @@ type UrlOrPredicate = string | RegExp | ((input: Request) => boolean);
 type RequestInput = string | URL | Request;
 type ResponseProvider = ResponseLike | ((request: Request) => ResponseLike | Promise<ResponseLike>);
 type ResponseLike = MockResponse | ResponseBody | Response;
-type ResponseBody = string;
+type ResponseBody = string | null | undefined;
 type ErrorOrFunction = Error | ResponseBody | ResponseProvider;
 
 export interface MockParams {
@@ -351,7 +351,7 @@ async function normalizeResponse(
 
   if (responseLike instanceof Response) {
     return responseLike;
-  } else if (typeof responseLike === 'string') {
+  } else if (typeof responseLike === 'string' || responseLike === null || responseLike === undefined) {
     return new Response(responseLike, params);
   } else {
     return patchUrl(new Response(responseLike.body, { ...params, ...responseLike }), responseLike.url ?? params?.url);

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -99,6 +99,42 @@ describe('testing mockResponse', () => {
     expect(fetch.mock.calls.length).toEqual(1);
     expect(fetch.mock.calls[0]![0]).toEqual(new URL('https://instagram.com'));
   });
+
+    it('should allow empty response bodies', async () => {
+        fetch.mockResponseOnce(null, { status: 204 });
+        fetch.mockResponseOnce(undefined, { status: 204 });
+        fetch.mockResponseOnce(() => null, { status: 204 });
+        fetch.mockResponseOnce(() => undefined, { status: 204 });
+        fetch.mockResponseOnce(() => Promise.resolve(null), { status: 204 });
+        fetch.mockResponseOnce(() => Promise.resolve(undefined), { status: 204 });
+        fetch.mockResponseOnce({ status: 204 });
+        fetch.mockResponseOnce(() => ({ status: 204 }));
+        fetch.mockResponseOnce(() => Promise.resolve({ status: 204 }));
+        fetch.mockResponseOnce(new Response(null, { status: 204 }));
+        fetch.mockResponseOnce(new Response(undefined, { status: 204 }));
+        fetch.mockResponseOnce(() => new Response(null, { status: 204 }));
+        fetch.mockResponseOnce(() => new Response(undefined, { status: 204 }));
+        fetch.mockResponseOnce(() => Promise.resolve(new Response(null, { status: 204 })));
+        fetch.mockResponseOnce(() => Promise.resolve(new Response(undefined, { status: 204 })));
+        fetch.mockResponseOnce('done');
+
+        expect(await request()).toBe('');
+        expect(await request()).toBe('');
+        expect(await request()).toBe('');
+        expect(await request()).toBe('');
+        expect(await request()).toBe('');
+        expect(await request()).toBe('');
+        expect(await request()).toBe('');
+        expect(await request()).toBe('');
+        expect(await request()).toBe('');
+        expect(await request()).toBe('');
+        expect(await request()).toBe('');
+        expect(await request()).toBe('');
+        expect(await request()).toBe('');
+        expect(await request()).toBe('');
+        expect(await request()).toBe('');
+        expect(await request()).toBe('done');
+    });
 });
 
 describe('testing mockResponses', () => {


### PR DESCRIPTION
Fixes https://github.com/IanVS/vitest-fetch-mock/issues/25