### PR TITLE
fix: make fetchMock globally available again

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,18 @@
 import { vi as vitest } from 'vitest';
 import type { Mock } from '@vitest/spy';
 
-// type-definitions
+declare global {
+  // eslint-disable-next-line no-var
+  var fetchMock: FetchMock;
+
+  // eslint-disable-next-line @typescript-eslint/no-namespace
+  namespace NodeJS {
+    interface Global {
+      fetchMock: FetchMock;
+    }
+  }
+}
+
 export type FetchMock = Mock<typeof global.fetch> & FetchMockObject;
 
 class FetchMockObject {
@@ -16,6 +27,7 @@ class FetchMockObject {
   // enable/disable
   enableMocks(): FetchMock {
     globalThis.fetch = this.mockedFetch;
+    globalThis.fetchMock = this.chainingResultProvider();
     return this.chainingResultProvider();
   }
 
@@ -333,7 +345,7 @@ export default function createFetchMock(vi: typeof vitest): FetchMock {
   }) as FetchMock;
 
   const fetchMock: FetchMock = mockedFetch as FetchMock;
-  const fetchMockObject = new FetchMockObject(mockedFetch, globalThis.fetch, () => fetchMock);
+  const fetchMockObject = new FetchMockObject(mockedFetch, originalFetch, () => fetchMock);
 
   copyMethods(fetchMockObject, fetchMock);
 

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -747,6 +747,16 @@ describe('conditional mocking', () => {
   });
 });
 
+it('works globally', async () => {
+    const fm = createFetchMock(vi);
+    fm.enableMocks();
+
+    fetchMock.mockResponseOnce('foo');
+    expect(await request()).toBe('foo');
+
+    fm.disableMocks();
+});
+
 it('enable/disable', async () => {
   expect(vi.isMockFunction(globalThis.fetch)).toBe(false);
   const fetch = createFetchMock(vi);

--- a/types/test.ts
+++ b/types/test.ts
@@ -1,7 +1,7 @@
 import setupFm, { type MockResponse } from 'vitest-fetch-mock';
 import { vi } from 'vitest';
 
-const fetchMock = setupFm(vi);
+const fm = setupFm(vi);
 
 fetchMock.mockResponse(JSON.stringify({foo: "bar"}));
 fetchMock.mockResponse(JSON.stringify({foo: "bar"}), {
@@ -108,10 +108,10 @@ function someSyncStringHandler(): string {
     return JSON.stringify({foo: "bar"});
 }
 
-fetchMock.enableMocks();
-fetchMock.disableMocks();
-fetchMock.doMock();
-fetchMock.dontMock();
-fetchMock.doMockOnce();
-fetchMock.dontMockOnce();
-fetchMock.mockOnce();
+fm.enableMocks();
+fm.disableMocks();
+fm.doMock();
+fm.dontMock();
+fm.doMockOnce();
+fm.dontMockOnce();
+fm.mockOnce();


### PR DESCRIPTION
Fixes https://github.com/IanVS/vitest-fetch-mock/issues/28, a regression that was introduced in https://github.com/IanVS/vitest-fetch-mock/commit/820015be1f7a93584dd35d67ea74bd3e60d4396e.

Although I think this it's a bad idea to just install stuff in the global scope, let's keep this to remain backwards compatible for now.

We could remove this in a future version and add a migration instruction to use rely on locally installed instances instead.