### PR TITLE
Support relative request URLs

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
     "test:watch": "vitest run --watch",
     "lint": "eslint src",
     "lint:fix": "eslint src --fix",
-    "format": "prettier src --write",
-    "format:check": "prettier src --check",
+    "format": "prettier src tests --write",
+    "format:check": "prettier src tests --check",
     "build": "tsc -p tsconfig.build.json"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
     "type-check": "tsc",
     "test": "vitest run",
     "test:watch": "vitest run --watch",
-    "lint": "eslint src",
-    "lint:fix": "eslint src --fix",
+    "lint": "eslint src tests",
+    "lint:fix": "eslint src tests --fix",
     "format": "prettier src tests --write",
     "format:check": "prettier src tests --check",
     "build": "tsc -p tsconfig.build.json"

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -100,6 +100,14 @@ describe('testing mockResponse', () => {
     expect(fetch.mock.calls[0]![0]).toEqual(new URL('https://instagram.com'));
   });
 
+  it('should support relative request urls', async () => {
+    fetch.mockResponseOnce(JSON.stringify({ data: 'abcde' }), { status: 200 });
+
+    const response = await fetch('folder/file.json').then((res) => res.json());
+
+    expect(response).toEqual({ data: 'abcde' });
+  });
+
   it('should allow empty response bodies', async () => {
     fetch.mockResponseOnce(null, { status: 204 });
     fetch.mockResponseOnce(undefined, { status: 204 });

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -100,41 +100,41 @@ describe('testing mockResponse', () => {
     expect(fetch.mock.calls[0]![0]).toEqual(new URL('https://instagram.com'));
   });
 
-    it('should allow empty response bodies', async () => {
-        fetch.mockResponseOnce(null, { status: 204 });
-        fetch.mockResponseOnce(undefined, { status: 204 });
-        fetch.mockResponseOnce(() => null, { status: 204 });
-        fetch.mockResponseOnce(() => undefined, { status: 204 });
-        fetch.mockResponseOnce(() => Promise.resolve(null), { status: 204 });
-        fetch.mockResponseOnce(() => Promise.resolve(undefined), { status: 204 });
-        fetch.mockResponseOnce({ status: 204 });
-        fetch.mockResponseOnce(() => ({ status: 204 }));
-        fetch.mockResponseOnce(() => Promise.resolve({ status: 204 }));
-        fetch.mockResponseOnce(new Response(null, { status: 204 }));
-        fetch.mockResponseOnce(new Response(undefined, { status: 204 }));
-        fetch.mockResponseOnce(() => new Response(null, { status: 204 }));
-        fetch.mockResponseOnce(() => new Response(undefined, { status: 204 }));
-        fetch.mockResponseOnce(() => Promise.resolve(new Response(null, { status: 204 })));
-        fetch.mockResponseOnce(() => Promise.resolve(new Response(undefined, { status: 204 })));
-        fetch.mockResponseOnce('done');
+  it('should allow empty response bodies', async () => {
+    fetch.mockResponseOnce(null, { status: 204 });
+    fetch.mockResponseOnce(undefined, { status: 204 });
+    fetch.mockResponseOnce(() => null, { status: 204 });
+    fetch.mockResponseOnce(() => undefined, { status: 204 });
+    fetch.mockResponseOnce(() => Promise.resolve(null), { status: 204 });
+    fetch.mockResponseOnce(() => Promise.resolve(undefined), { status: 204 });
+    fetch.mockResponseOnce({ status: 204 });
+    fetch.mockResponseOnce(() => ({ status: 204 }));
+    fetch.mockResponseOnce(() => Promise.resolve({ status: 204 }));
+    fetch.mockResponseOnce(new Response(null, { status: 204 }));
+    fetch.mockResponseOnce(new Response(undefined, { status: 204 }));
+    fetch.mockResponseOnce(() => new Response(null, { status: 204 }));
+    fetch.mockResponseOnce(() => new Response(undefined, { status: 204 }));
+    fetch.mockResponseOnce(() => Promise.resolve(new Response(null, { status: 204 })));
+    fetch.mockResponseOnce(() => Promise.resolve(new Response(undefined, { status: 204 })));
+    fetch.mockResponseOnce('done');
 
-        expect(await request()).toBe('');
-        expect(await request()).toBe('');
-        expect(await request()).toBe('');
-        expect(await request()).toBe('');
-        expect(await request()).toBe('');
-        expect(await request()).toBe('');
-        expect(await request()).toBe('');
-        expect(await request()).toBe('');
-        expect(await request()).toBe('');
-        expect(await request()).toBe('');
-        expect(await request()).toBe('');
-        expect(await request()).toBe('');
-        expect(await request()).toBe('');
-        expect(await request()).toBe('');
-        expect(await request()).toBe('');
-        expect(await request()).toBe('done');
-    });
+    expect(await request()).toBe('');
+    expect(await request()).toBe('');
+    expect(await request()).toBe('');
+    expect(await request()).toBe('');
+    expect(await request()).toBe('');
+    expect(await request()).toBe('');
+    expect(await request()).toBe('');
+    expect(await request()).toBe('');
+    expect(await request()).toBe('');
+    expect(await request()).toBe('');
+    expect(await request()).toBe('');
+    expect(await request()).toBe('');
+    expect(await request()).toBe('');
+    expect(await request()).toBe('');
+    expect(await request()).toBe('');
+    expect(await request()).toBe('done');
+  });
 });
 
 describe('testing mockResponses', () => {
@@ -822,15 +822,15 @@ describe('overloads', () => {
     expect(await request()).toBe('i');
   });
 });
-  
+
 it('works globally', async () => {
-    const fm = createFetchMock(vi);
-    fm.enableMocks();
+  const fm = createFetchMock(vi);
+  fm.enableMocks();
 
-    fetchMock.mockResponseOnce('foo');
-    expect(await request()).toBe('foo');
+  fetchMock.mockResponseOnce('foo');
+  expect(await request()).toBe('foo');
 
-    fm.disableMocks();
+  fm.disableMocks();
 });
 
 it('enable/disable', async () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,8 @@
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "lib": [
-      "es2022"
+      "es2022",
+      "dom",
     ],
     "baseUrl": "./",
     "paths": {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,4 +6,7 @@ export default defineConfig({
       'vitest-fetch-mock': './src/index',
     },
   },
+  test: {
+    environment: 'jsdom',
+  },
 });


### PR DESCRIPTION
Fixes #31 

This takes an approach similar to MSW, whereby we will add the absolute base url to a request if we're able to.  See https://developer.mozilla.org/en-US/docs/Web/API/Window/fetch#resource for which absolute base url is used in window vs worker contexts.