### PR TITLE
fix(types): import `Mock` type from vitest

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,4 @@
-import { vi as vitest } from 'vitest';
-import type { Mock } from '@vitest/spy';
+import { vi as vitest, type Mock } from 'vitest';
 
 declare global {
   // eslint-disable-next-line no-var


### PR DESCRIPTION
The `Mock` type is exported by `vitest`, so importing from `@vitest/spy` is unnecessary. Also, when installed with pnpm, the `@vitest/spy` package is inaccessible to the type definitions of this package, because `@vitest/spy` is not a dependency of it.
